### PR TITLE
Error in question

### DIFF
--- a/quarto/zeros.qmd
+++ b/quarto/zeros.qmd
@@ -298,14 +298,11 @@ numericq(val, 1e-1)
 #### Question
 
 
-The polynomial $f(x) = x^5 - 6x^3 - 6x^2 -7x - 6$ has three real roots. Which of the following values is one of them? Try to solve this graphically.
+The polynomial $f(x) = x^5 - 6x^3 - 6x^2 -7x - 6$ has three real roots. Which of the following values is not one of them? Try to solve this graphically.
 
 
 ```{julia}
 #| echo: false
-using Random
-rts =[-2, -1, 3];
-x = rts[randperm(3)[1]];
 choices = [5, -1, 3, -2]
 answer = 1;
 radioq(choices, answer)


### PR DESCRIPTION
The random selection of `x` from the actual roots is never used in the answer. Instead the three correct roots are hardcoded together with an incorrect choice, and the incorrect choice given as the actual correct choice to `radioq`.

This edit is the smallest that corrects the question - asking the student to find the one number that is _not_ one of the real roots. And since the resulting code does not use the roots in `rts` or the random selection, that code has been removed.