### PR TITLE
Hide accidentally exposed question code

### DIFF
--- a/quarto/zeros.qmd
+++ b/quarto/zeros.qmd
@@ -264,6 +264,7 @@ Graphically estimate the one zero of $f(x) = e^x - x^3$ over the interval $[0,4]
 
 
 ```{julia}
+#| echo: false
 val = fzero(x -> e^x - x^3, [0,4])
 numericq(val, 1e-1)
 ```
@@ -596,6 +597,7 @@ There is another root in the interval $[-10, 0]$ for the function $f(x) = e^x - 
 
 
 ```{julia}
+#| echo: false
 f(x) = exp(x) - x^2
 val = find_zero(f, (-10, 0));
 numericq(val, 1e-3)


### PR DESCRIPTION
Some quiz questions accidentally expose their code in the compiled document.