### PR TITLE
Wrong limit expected in answer.

### DIFF
--- a/quarto/limits.qmd
+++ b/quarto/limits.qmd
@@ -629,7 +629,7 @@ $$
 ```{julia}
 #| echo: false
 f(x) = (x - 27)/(x^(1/3) - 3)
-numericq(0, 0.001)
+numericq(27, 0.001)
 ```
 
 #### Question


### PR DESCRIPTION
Question asks for the limit of $f(x) = \frac{x - 27}{x^{1/3} - 3}$ as $x\to 27$. The question code gives 0 as correct answer, while both a graphical investigation and the limit command in `MTH229` give the answer 27, eg:

```
In [32]: lim(x -> (x-27)/(x^(1/3)-3), 27)
Out[32]: 6×2 Matrix{Float64}:
 27.1     27.0333
 27.01    27.0033
 27.001   27.0003
 27.0001  27.0
 27.0     27.0
 27.0     27.0
```

If we series-expand the cube root around x=27 we get:

(x-27) / (x^(1/3)-3) = (x-27) / (3 + (x-27)/27 + O(x^2) - 3) ~ (x-27) / (x/27 - 1) = (1-27/x) / (1/27-1/x) → 27