### PR TITLE
Update limits.qmd

### DIFF
--- a/quarto/limits.qmd
+++ b/quarto/limits.qmd
@@ -1086,7 +1086,7 @@ Floating point approximations differ depending on the location. Look at the diff
 #### Questions
 
 
-is `eps() == nextfloat(1.0)`?
+is `eps() == nextfloat(1.0)-1`?
 
 
 ```{julia}


### PR DESCRIPTION
`nextfloat(1.0)` is definitely not the same as `eps()`, since `eps()` is very small and `nextfloat(1.0)` is a little over 1.0.