### PR TITLE
`linspace` deprecated, use `range` instead

### DIFF
--- a/quarto/derivatives.qmd
+++ b/quarto/derivatives.qmd
@@ -861,7 +861,7 @@ We can compare the error at many different points with the following construct
 #| eval: false
 f(x) = exp(-x)*sin(x)
 fp(x) = exp(-x)*(cos(x) - sin(x))
-[abs(f'(x) - fp(x) ) for x in linspace(0, pi, 25)]
+[abs(f'(x) - fp(x) ) for x in range(0, pi, 25)]
 ```
 
 What is the order (exponent) of the largest difference above?


### PR DESCRIPTION
In Julia 1.8, `linspace` throws an error - it's been deprecated and should be replaced with `range`.