### PR TITLE
Update newton.qmd

### DIFF
--- a/quarto/newton.qmd
+++ b/quarto/newton.qmd
@@ -321,7 +321,7 @@ We revisit a problem from a previous project, finding zeroes of the function $f(
 ```{julia}
 f(x) = exp(x) - x^4
 x = 2
-newton(f, 2)  # newton will use automatic differentiation for the derivative
+xstar = newton(f, 2)  # newton will use automatic differentiation for the derivative
 ```
 
 It took 8 steps and we are this close:


### PR DESCRIPTION
Printout uses stale definitions of `xstar` that don't capture the calculation being discussed.